### PR TITLE
[0.2.5] Update Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-kahvesi",
   "description": "grunt plugin for generating istanbul + mocha coverage reports",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "homepage": "https://github.com/tonylukasavage/grunt-kahvesi",
   "author": {
     "name": "Tony Lukasavage",
@@ -43,7 +43,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "istanbul": "^0.3.8",
-    "mocha": "^1.21.5"
+    "istanbul": "^0.3.17",
+    "mocha": "^2.2.5"
   }
 }


### PR DESCRIPTION
The version of mocha is too old; this updates it so that it will install properly as a dependency and operate smoothly with other modules.
